### PR TITLE
feat(ci): upload artifacts during attestation

### DIFF
--- a/.github/contracts/release.cue
+++ b/.github/contracts/release.cue
@@ -1,3 +1,7 @@
 schemaVersion: "v1"
-materials: []
+materials: [
+	{type: "ARTIFACT", name: "goket-linux-amd64", output: true},
+	{type: "ARTIFACT", name: "goket-linux-arm", output: true},
+	{type: "ARTIFACT", name: "goket-linux-arm64", output: true},
+]
 runner: type: "GITHUB_ACTION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           chainloop version
 
       - name: Initialize Attestation
-        run: chainloop attestation init --contract-revision 2
+        run: chainloop attestation init
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -47,6 +47,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
+      - name: Add Attestation Artifacts (binaries)
+        run: |
+          echo -n '${{ steps.release.outputs.artifacts }}' | jq -r '.[] | select(.type=="Binary" and .goos=="linux") | { "name": "\(.extra.ID)-\(.goos)-\(.goarch)", "path":"\(.path)"} | @base64' | while read i; do
+              BINARY_NAME=$(echo "${i}" | base64 --decode | jq -r ${1} .name)
+              BINARY_PATH=$(echo "${i}" | base64 --decode | jq -r ${1} .path)
+              chainloop attestation add --name ${BINARY_NAME} --value ${BINARY_PATH} 
+            done
 
       - name: Finish and Record Attestation
         if: ${{ success() }}


### PR DESCRIPTION
This PR adds some code that runs `chainloop att add` to upload the generated binaries

The result of a test can be seen [here](https://github.com/goket-app/goket/actions/runs/3841373075/jobs/6541516633)

You might notice that the attestation result now contains a `material` table with all the binaries in it.

```
┌───────────────────┬────────────────────────────────────────────────────────────┐
│ Initialized At    │ 04 Jan 23 20:29 UTC                                        │
├───────────────────┼────────────────────────────────────────────────────────────┤
│ Workflow          │ 3da0b2a9-f56b-4e7d-bf41-6f80b2c92faf                       │
│ Name              │ release                                                    │
│ Team              │ goket-app maintainers                                      │
│ Project           │ goket-app                                                  │
│ Contract Revision │ 3                                                          │
│ Runner Type       │ GITHUB_ACTION                                              │
│ Runner URL        │ https://github.com/goket-app/goket/actions/runs/3841373075 │
└───────────────────┴────────────────────────────────────────────────────────────┘
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                                                                                 │
├───────────────────┬──────────┬─────┬──────────┬───────────┬───────────────────────────────────────────────────────────────────────────────┤
│ NAME              │ TYPE     │ SET │ REQUIRED │ IS OUTPUT │ VALUE                                                                         │
├───────────────────┼──────────┼─────┼──────────┼───────────┼───────────────────────────────────────────────────────────────────────────────┤
│ goket-linux-amd64 │ ARTIFACT │ Yes │ Yes      │ x         │ goket@sha256:1dab2d24af5de96959dcaa4f69df43319610cb910e106d8fa4fed6b1abdb2295 │
│ goket-linux-arm   │ ARTIFACT │ Yes │ Yes      │ x         │ goket@sha256:51719470665e97d4c18e0879a23b93c688e7d56fabf738faf42ca260479ce314 │
│ goket-linux-arm64 │ ARTIFACT │ Yes │ Yes      │ x         │ goket@sha256:b64ade729aa7796b4c2bd3a172d0bd9cc284f51587[11](https://github.com/goket-app/goket/actions/runs/3841373075/jobs/6541516633#step:9:12)1[15](https://github.com/goket-app/goket/actions/runs/3841373075/jobs/6541516633#step:9:16)ec8ff4c9fe1d6869a │
└───────────────────┴──────────┴─────┴──────────┴───────────┴───────────────────────────────────────────────────────────────────────────────┘
```

These binaries have been uploaded automatically to the CAS, your OCI registry, so they can be downloaded if needed, i.e

```bash
$ chainloop artifact download -d sha256:1dab2d24af5de96959dcaa4f69df43319610cb910e106d8fa4fed6b1abdb2295
```