### PR TITLE
feat(ci): add sbom

### DIFF
--- a/.github/contracts/release.cue
+++ b/.github/contracts/release.cue
@@ -3,5 +3,7 @@ materials: [
 	{type: "ARTIFACT", name: "goket-linux-amd64", output: true},
 	{type: "ARTIFACT", name: "goket-linux-arm", output: true},
 	{type: "ARTIFACT", name: "goket-linux-arm64", output: true},
+	// Software Bill Of Materials for the generated binaries
+	{type: "SBOM_CYCLONEDX_JSON", name: "sbom"},
 ]
 runner: type: "GITHUB_ACTION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,13 @@ jobs:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
 
+      - uses: anchore/sbom-action@v0
+        with:
+          path: ./dist/
+          format: cyclonedx-json
+          artifact-name: sbom.cyclonedx.json
+          output-file: /tmp/sbom.cyclonedx.json
+
       - name: Add Attestation Artifacts (binaries)
         run: |
           echo -n '${{ steps.release.outputs.artifacts }}' | jq -r '.[] | select(.type=="Binary" and .goos=="linux") | { "name": "\(.extra.ID)-\(.goos)-\(.goarch)", "path":"\(.path)"} | @base64' | while read i; do

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,6 +63,9 @@ jobs:
               chainloop attestation add --name ${BINARY_NAME} --value ${BINARY_PATH} 
             done
 
+      - name: Add Attestation Artifacts (SBOM)
+        run: chainloop attestation add --name sbom --value /tmp/sbom.cyclonedx.json
+
       - name: Finish and Record Attestation
         if: ${{ success() }}
         run: |


### PR DESCRIPTION
* Generates an Software Bill of materials in CycloneDX format of the generated binaries.
* This SBOM  is added to the GitHub release.
* The SBOM is sent now to `chainloop`

See https://github.com/goket-app/goket/actions/runs/3842220789/jobs/6543305376

```sh
$ chainloop wf run describe --id 6e172d7b-1f68-493d-bd6f-57b6ee2ea892
┌─────────────────────────────────────────────────────────────────────────────┐
│ Workflow                                                                    │
├────────────────┬────────────────────────────────────────────────────────────┤
│ ID             │ 3da0b2a9-f56b-4e7d-bf41-6f80b2c92faf                       │
│ Name           │ release                                                    │
│ Team           │ goket-app maintainers                                      │
│ Project        │ goket-app                                                  │
├────────────────┼────────────────────────────────────────────────────────────┤
│ Workflow Run   │                                                            │
├────────────────┼────────────────────────────────────────────────────────────┤
│ ID             │ 6e172d7b-1f68-493d-bd6f-57b6ee2ea892                       │
│ Initialized At │ 04 Jan 23 22:48 UTC                                        │
│ Finished At    │ 04 Jan 23 22:49 UTC                                        │
│ State          │ success                                                    │
│ Runner Link    │ https://github.com/goket-app/goket/actions/runs/3842220789 │
├────────────────┼────────────────────────────────────────────────────────────┤
│ Statement      │                                                            │
├────────────────┼────────────────────────────────────────────────────────────┤
│ Payload Type   │ application/vnd.in-toto+json                               │
│ Verified       │ false                                                      │
└────────────────┴────────────────────────────────────────────────────────────┘
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Materials                                                                                                                             │
├───────────────────┬─────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────┤
│ NAME              │ TYPE                │ VALUE                                                                                       │
├───────────────────┼─────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────┤
│ goket-linux-arm64 │ ARTIFACT            │ goket@sha256:3a358e8b2d302dd6f6f5cd60f2aca4086a041d092ed137b67a497afa3c371ae8               │
│ sbom              │ SBOM_CYCLONEDX_JSON │ sbom.cyclonedx.json@sha256:34dd414116c98e1162c75a8df2353ebe7c46416f6abb161f5591b37f35a2a1af │
│ goket-linux-amd64 │ ARTIFACT            │ goket@sha256:8f872f55894acb5c6709d9b8641ff8bbcce72662e563f953accb1dc50f126abe               │
│ goket-linux-arm   │ ARTIFACT            │ goket@sha256:78c665cb34a585fe4c704a3b41396acda10a8435ac9fc67bb62c6b29dce99de9               │
└───────────────────┴─────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────┘
```

Notice the `sbom` material stored, as any other material, it can be downloaded via `chainloop artifact download -d [digest]`
